### PR TITLE
Install Elm globally on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,6 +70,9 @@ jobs:
       - run: |
           cd frontend
           npm install
+          # Remove once the global Elm dep is removed
+          # https://github.com/tcoopman/elm-css-webpack-loader/issues/20
+          npm install -g elm
 
       - save_cache:
           paths:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Photobank
 
+[![CircleCI](https://circleci.com/gh/lpil/photobank.svg?style=svg)](https://circleci.com/gh/lpil/photobank)
+
 A photo sharing app. :)
 
 


### PR DESCRIPTION
Currently elm-css-webpack-loader does not support local
installations of Elm.

https://github.com/tcoopman/elm-css-webpack-loader/issues/20